### PR TITLE
Lock middleman search gem down to a specific version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,4 +13,4 @@ gem 'govuk_tech_docs'
 
 # Overrride middleman-search with our fork.
 # See: https://github.com/manastech/middleman-search/pull/24
-gem 'middleman-search', :git => "git://github.com/alphagov/middleman-search.git"
+gem 'middleman-search', git: 'git://github.com/alphagov/middleman-search.git', ref: '19df7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
   remote: git://github.com/alphagov/middleman-search.git
-  revision: 31def1438132c6979ec1930cea8940d68e36dc10
+  revision: 19df7578dc20621b60dfbc5e4dc986ac4f064c6b
+  ref: 19df7578dc20621b60dfbc5e4dc986ac4f064c6b
   specs:
     middleman-search (0.10.0)
       execjs (~> 2.6)


### PR DESCRIPTION
On the latest version of this we get an error:
Stack Level Too Deep

It looks like this commit introduced the bug:
 https://github.com/alphagov/middleman-search/commit/50d072378c6f92a78ea02fed366ec6453aea8552

Lock down the gem to a version before that.