### PR TITLE
Fix error with middleman-search gem version bump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,8 @@ WORKDIR /usr/src/app
 
 COPY Gemfile Gemfile.lock .ruby-version ./
 
-RUN apk --update add g++ musl-dev make git nodejs
-RUN bundle install
+RUN apk --update add g++ musl-dev make git nodejs && bundle install
 
 COPY . .
 
-RUN bundle exec middleman build
+CMD bundle exec middleman build


### PR DESCRIPTION
When booting up the container, it was giving an error that the gem
wasn't installed.  Change the docker file to fix this.