### PR TITLE
Revert Dockerfile syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,9 @@ WORKDIR /usr/src/app
 
 COPY Gemfile Gemfile.lock .ruby-version ./
 
-RUN apk --update add g++ musl-dev make git nodejs && bundle install
+RUN apk --update add g++ musl-dev make git nodejs
+RUN bundle install
 
 COPY . .
 
-CMD bundle exec middleman build
+RUN bundle exec middleman build

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: git://github.com/alphagov/middleman-search.git
   revision: 19df7578dc20621b60dfbc5e4dc986ac4f064c6b
-  ref: 19df7578dc20621b60dfbc5e4dc986ac4f064c6b
+  ref: 19df7
   specs:
     middleman-search (0.10.0)
       execjs (~> 2.6)


### PR DESCRIPTION
There was a problem previously where bundle install failed on Jenkins.

I thought this had to do with the way the docker image is built but
turns out that the git sha in the Gemfile.lock changed to a shorter
version.