### PR TITLE
Change links according to feedback

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -4,14 +4,12 @@ host: docs.govwifi.service.gov.uk
 # Header-related options
 show_govuk_logo: true
 service_name: GovWifi
-service_link: https://www.larry-the-cat.service.gov.uk
+service_link: https://govwifi-product-page.cloudapps.digital/
 
 # Links to show on right-hand-side of header
 header_links:
-  About: https://www.larry-the-cat.service.gov.uk
-  Get Started: https://www.larry-the-cat.service.gov.uk/get-started
   Documentation: /
-  Support: https://www.larry-the-cat.service.gov.uk/support
+  Sign In: https://admin-platform.wifi.service.gov.uk/
 
 # Enables search functionality. This indexes pages only and is not recommended for single-page sites.
 enable_search: true


### PR DESCRIPTION
- Tech docs logo should link back to product page
- Tech docs - Remove Get started, remove support and about add sign in

<img width="1276" alt="screen shot 2018-09-04 at 16 37 48" src="https://user-images.githubusercontent.com/921198/45041916-605faf80-b061-11e8-846d-5f3ff6e7dada.png">
