### PR TITLE
Remove dead-ends and email guidance

### DIFF
--- a/source/documentation/before_you_start.md
+++ b/source/documentation/before_you_start.md
@@ -8,9 +8,12 @@ You can use it as a guest wifi making it easier for guests to get online
 
 **Pricing**
 
-GovWifi is free to use for government and public sector organisations and arm’s length bodies
-GovWifi is an authentication service and therefore will not be responsible for maintenance or support requests
+GovWifi is free to use for government and public sector organisations and arm’s length bodies.
+
+GovWifi is an authentication service only - we do not provide support directly to individual users, or assist in setting up or maintaining your local network.
+
 Costs associated with GovWifi could include:
+
 - time spend for developer work
 - testing GovWifi, which may be outside your existing service agreement with your wireless provider, such as BT or Cisco
 - support desk and time being spent on user support queries
@@ -25,9 +28,11 @@ Set up and maintenance as well as scaling GovWifi will need an IT team - this mi
 Administrators must make sure their wifi meets these requirements
 
 Memorandum of Understanding
-You will need to sign the Memorandum of Understanding (MoU) before joining GovWifi. You can download, sign and return the MoU yourself, or send it a colleague to sign. Whoever signs the MoU must have permission to sign off and procure services in your organisations.
+You will need to sign the Memorandum of Understanding (MoU) before joining GovWifi. You can sign it yourself, or send it a colleague to sign.
 
-[download MOU link]
+Whoever signs the MoU must have permission to sign off and procure services in your organisations.
+
+Contact us at [govwifi-support@digital.cabinet-office.gov.uk](govwifi-support@digital.cabinet-office.gov.uk) for a copy of this document.
 
 **GovWifi Terms and conditions for end users**
 

--- a/source/documentation/leave.md
+++ b/source/documentation/leave.md
@@ -2,8 +2,8 @@
 
 **You want to remove a building**
 
-If you want to remove GovWifi from one of your sites, please follow these steps:
+If you want to remove GovWifi from one of your sites, please contact us at [govwifi-support@digital.cabinet-office.gov.uk](govwifi-support@digital.cabinet-office.gov.uk).
 
 **You want to sign off entirely**
 
-If you don’t want to continue to use GovWifi for your organisation, then follow this steps:
+If you don’t want to continue to use GovWifi for your organisation, please contact us at [govwifi-support@digital.cabinet-office.gov.uk](govwifi-support@digital.cabinet-office.gov.uk).

--- a/source/documentation/phase1.md
+++ b/source/documentation/phase1.md
@@ -1,42 +1,26 @@
 # Phase 1: Create a new wifi installation
 
-## Apply to create a new GovWifi
+## Get an account
 
-Complete and electronically sign this [application form](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/675990/GovWifi_-_create_a_new_installation.odt) (ODT, 17.1KB) to request an installation. You must do this so the GovWifi team can approve your application to create a new installation.
+Your department, agency or team must have a GovWifi account. Sign up for an account at the [GovWifi admin platform](https://admin-platform.wifi.service.gov.uk/users/sign_up).
 
-Send the completed document to [govwifi-support@digital.cabinet-office.gov.uk](govwifi-support@digital.cabinet-office.gov.uk). In the email body, you must include:
+To provide you with an account, we need to store some personal data about you. Please see our privacy notice for details.
 
-- the email address and mobile phone number of each person you’d like to set up as an administrator
-- the name of the organisation or group you represent
-- a shared and monitored email address - the GovWifi support team will send service notifications to this address
+Once you have an account, you can access the GovWifi admin platform. This tool allows you to manage your GovWifi configuration.
 
-The GovWifi team will contact you when your application has been approved. Do not proceed to step 2 until you’ve received confirmation.
+If you are having trouble signing up for an account, contact us at [govwifi-support@digital.cabinet-office.gov.uk](govwifi-support@digital.cabinet-office.gov.uk).
 
 ## Establish your public IP addresses
 
-Remote Authentication Dial-In User Service (RADIUS) traffic usually originates from the management interface of your wifi controller. Find out if you have an existing network address translation (NAT) rule, or whether you need a new one. If you have multiple internet connections it may be possible for traffic to originate from a different IP address in the event of a primary link failure. Make sure you add all your IP addresses if you have multiple internet connections.
+Remote Authentication Dial-In User Service (RADIUS) traffic usually originates from the management interface of your wifi controller. Find out if you have an existing network address translation (NAT) rule, or whether you need a new one.
 
-## Register your site to GovWifi
+If you have multiple internet connections it may be possible for traffic to originate from a different IP address in the event of a primary link failure. Make sure you add all your IP addresses if you have multiple internet connections.
 
-> DEPRECATED: Registration of new sites is handled now by [GovWifi Admin](https://admin-platform.wifi.service.gov.uk/). Email workflow will be turned off in the near future.
-
-Send an email from the individual email address you registered in step 1 to newsite@wifi.service.gov.uk - this is an automated service. If you have more than one site, register each site in a separate email.
-
-Your email must include:
-
-- the first line of your government building street address - put this in the subject field
-- the list of public IP addresses that your RADIUS requests will originate from (one on each line) - put this in the body of the email
-- in a separate line, under the IP addresses, write your postcode in the format: Postcode: XXXX XXX
-
-Before you send the email, make sure your email system doesn’t block encrypted attachments.
-
-You’ll receive an encrypted PDF via email that contains configuration details and the RADIUS key to configure your wireless infrastructure. The password to decrypt this file will be sent to your phone in a text message.
-
-You can start using the service the day after you register your site, because the RADIUS servers update overnight.
+You can manage your IP addresses in the [GovWifi admin platform](https://admin-platform.wifi.service.gov.uk/).
 
 ## Configure your infrastructure
 
-> Your secret key, RADIUS IP addresses and more can now be viewed in [GovWifi Admin](https://admin-platform.wifi.service.gov.uk/).
+Your secret key, established IP addresses and more can be managed in the [GovWifi admin platform](https://admin-platform.wifi.service.gov.uk/).
 
 1. Create a firewall rule to allow traffic on UDP ports 1812 and 1813 to reach the RADIUS IP addresses assigned to you.
 

--- a/source/documentation/phase2.md
+++ b/source/documentation/phase2.md
@@ -49,11 +49,3 @@ GovWifi must be the highest priority service set identifier (SSID) in your organ
 Add the following to your users’ login script (you may need to change the interface name for your environment):
 
 netsh wlan set profileorder name="GovWifi" interface="Wi-Fi" priority=1
-
-
-**Default behaviour on operating systems**
-
-The table below shows the default behaviour when connecting to GovWifi on different operating systems.
-
-[IMAGE HERE]
-

--- a/source/documentation/phase3.md
+++ b/source/documentation/phase3.md
@@ -1,15 +1,13 @@
 # Phase 3: Test
 
-Most organisations test a product they want to scale. For GovWifi, we recommend a test phase, which you start by signing up for GovWifi. This had following benefits for you:
+Most organisations test a product they want to scale. For GovWifi, we recommend a test phase, changing some subset of your infrastructure to test authenticating users.
 
 ## Steps of testing GovWifi
 
-- Sign up for GovWifi by following step 1 of Create a new wifi installation
-- Sign the MoU
-- Sign up your administrators
-- Add the details of one or two buildings where you’d like to test GovWifi, instructions are here (linking to adding buildings)
-- Install your access points
-- Check to see if the IP is active
+- Sign up for a GovWifi by following step 1 of Create a new wifi installation
+- Sign the MoU (contact us at [govwifi-support@digital.cabinet-office.gov.uk](govwifi-support@digital.cabinet-office.gov.uk) for a copy of this document)
+- Add the public IP addresses of your authenticators, using the [GovWifi admin platform](https://admin-platform.wifi.service.gov.uk/), so that they can connect to GovWifi
+- Configure your authenticator(s) (e.g. access points) to use the GovWifi RADIUS servers
 - Identify a number of users who will test GovWifi, and collect feedback about the service
 - Make sure there is a local help desk that can deal with incoming support queries
 - At the end of the trial collect statistics and performance results
@@ -33,19 +31,10 @@ Tell your employees about the GovWifi test and provide instructions how to use i
 
 **How long to test**
 
-For guest wifi you can do tests for one day. To get the best results, you should do at least 5 tests, over a  2 week period.
+For guest wifi you can do tests for one day. To get the best results, you should do at least 5 tests, over a 2 week period.
 
-**How to measure**
-
-Track the performance on your dashboard. It will give you an indication of how the network is performing. You should also enter manual support requests into the dashboard, so this can be included in the final result of the testing.
-
+<!-- **How to measure**
 **What to do next**
-When the trial is completed, you will receive suggestions how to proceed. Depending on your test results, this might be one of the following:
-
-- All good - you can scale up and go live
-- Make adjustments, run another test
-- We detected performance issues - what can wedo to fix them?
-
 ## General information
 ## How to test
-## How to measure performance
+## How to measure performance -->

--- a/source/documentation/phase4.md
+++ b/source/documentation/phase4.md
@@ -2,19 +2,15 @@
 
 ## When to go live
 
-You should make sure that you have tested GovWifi before rolling it out to the organisation. Consider those steps:
+You should make sure that you have tested GovWifi before rolling it out to the organisation. Consider these steps:
+
 - Track performance of the testing
-- Ask users about their experience of signing up an using GovWifi
+- Ask users about their experience of signing up and using GovWifi
 - Ask users that have been already signed up before to see if the device will connect automatically
 - See how security technology (VPN, locked down computers) are corresponding with the network
 - Brief your support desk team and download the troubleshooting guideline for the help desk
 
-**Before you go live**
-
-Before you go live, please check this points:
-
+<!-- **Before you go live**
 **Inform your users**
-
-Advertise the service in your buildings to tell users how to sign up to GovWifi.
-
 [DOWNLOAD POSTER]
+ -->

--- a/source/documentation/phase5.md
+++ b/source/documentation/phase5.md
@@ -2,12 +2,13 @@
 
 ## Viewing logs
 
-TBC
+Planned features for the [GovWifi admin platform](https://admin-platform.wifi.service.gov.uk/users/sign_up) will display your organisation's usage of GovWifi.
+
+In the meantime, if you need logs/information to diagnose a problem, contact us at [govwifi-support@digital.cabinet-office.gov.uk](govwifi-support@digital.cabinet-office.gov.uk).
 
 **Site configuration information**
 
-You can view your site configuration information in [GovWifi Admin](https://admin-platform.wifi.service.gov.uk/)
-TBC
+You can view and update your GovWifi configuration in the [GovWifi admin platform](https://admin-platform.wifi.service.gov.uk/)
 
 **Log traffic, detect malware and block users**
 
@@ -17,10 +18,7 @@ Traffic monitoring and logging is performed by the organisation providing the wi
 
 You can [request logs for specific users](https://www.gov.uk/guidance/set-up-govwifi-on-your-infrastructure#logs) and, if necessary, deny service to them by blocking their hardware address on your infrastructure. In the event of a serious issue contact GovWifi support for assistance.
 
-**Administration Platform**
-
+<!-- **Administration Platform**
 **Add locations**
-
 **Change admins**
-
-**Request information**
+**Request information** -->

--- a/source/documentation/phase6.md
+++ b/source/documentation/phase6.md
@@ -2,7 +2,9 @@
 
 ## Advertise GovWifi
 
-Tell users how to sign up to GovWifi in your organisation. GDS will send you a poster when you register your site.
+Tell users how to sign up to GovWifi in your organisation.
+
+Informational posters are planned, but not yet available.
 
 ## Withdraw legacy services
 

--- a/source/documentation/requirements.md
+++ b/source/documentation/requirements.md
@@ -78,4 +78,4 @@ You must provide an internet connection with a basic content filtering service t
 - Misuse of GovWifi according to the acceptable use policy should be dealt with using your local access controls to remove access to that device.
 - We do not provide a centralised acceptable usage policy across all GovWifi, instead each organisation should be configuring their own.
 
-**Wireless AP configuration Security**
+<!-- **Wireless AP configuration Security** -->

--- a/source/documentation/troubleshooting.md
+++ b/source/documentation/troubleshooting.md
@@ -2,9 +2,11 @@
 
 ## For support desks
 
-Members of the support and help desk will potentially get support queries from employees or guests that struggle to get access to the GovWifi network. You can download a hard copy of a troubleshooting guideline for dealing and resolving those issues.
+Members of the support and help desk will potentially get support queries from employees or guests that struggle to get access to the GovWifi network.
 
-[DOWNLOAD LINK]
+We plan to provide downloadable troubleshooting guidelines for dealing and resolving those issues, but in the meantime, refer to this documentation.
+
+If you can't resolve the issue locally, contact us at [govwifi-support@digital.cabinet-office.gov.uk](govwifi-support@digital.cabinet-office.gov.uk).
 
 ## For network administrators
 


### PR DESCRIPTION
Email guidance still existed in these docs - admittedly marked by giant deprecation notices - this PR removes them for the sake of clarity.

This PR also points users to our support e-mail address or the new admin platform when they'd otherwise hit a deadend, which was lots of places - looking for an MOU, looking for logs, looking for help in general.

Also correct some list formatting and some confusing blank headings (though some headings are left in, commented, to avoid stepping on toes - happy to remove them instead).