### PR TITLE
Include support link and consistent layout

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -9,6 +9,7 @@ service_link: https://wifi.service.gov.uk
 # Links to show on right-hand-side of header
 header_links:
   Documentation: /
+  Support: https://admin.wifi.service.gov.uk/help
   Admin: https://admin.wifi.service.gov.uk/users/sign_in
 
 # Enables search functionality. This indexes pages only and is not recommended for single-page sites.

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -1,1 +1,33 @@
 @import "govuk_tech_docs";
+
+.header.header--full-width .header__container {
+  @include media(desktop) {
+    max-width: 960px;
+    margin: 0 auto;
+  }
+}
+
+.toc {
+  @include media(desktop) {
+    padding: 30px 10px 0 0;
+  }
+}
+
+.app-pane__body {
+  @include media(desktop) {
+    max-width: 960px;
+    margin: 0 auto;
+  }
+}
+
+.app-pane__body {
+  border-top: none;
+
+  @include media(desktop) {
+    border-top: 10px solid #005ea5;
+  }
+}
+
+.header.header--full-width {
+  border-bottom: none;
+}


### PR DESCRIPTION
This top navigation is shared by 3 separate apps, we want it to feel
like you are browsing one app.

All 3 applications should have the same navigation items available for
easy browsing and should look consistent.

This sets a max width on desktop to match the layout of the admin and
product page.

<img width="1054" alt="screen shot 2018-10-30 at 14 38 46" src="https://user-images.githubusercontent.com/1215147/47726045-a005da80-dc51-11e8-8bc0-c4e4aade0447.png">
