### PR TITLE
Make primary navigation consistent with other apps

### DIFF
--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -4,7 +4,6 @@
   @include media(desktop) {
     max-width: 960px;
     margin: 0 auto;
-    padding: 9px 0 8px;
   }
 }
 
@@ -34,13 +33,6 @@
 }
 
 .header__navigation li {
-  @include media(desktop) {
-    margin: 7px 0 0 18px;
-    min-width: 60px;
-    text-align: right;
-  }
-}
-
-.govuk-logo {
-  margin-right: 5px;
+  min-width: 55px;
+  text-align: right;
 }


### PR DESCRIPTION
We sometimes have "Admin" as a menu item, and when you are on the admin,
it says "Sign in".  This uses up a different amount of space, so set a
min width to ensure the navigation doesn't mover around when you browse
between the apps.