### PR TITLE
Redirect all requests to docs.wifi.service.gov.uk

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,17 @@
+worker_processes 1;
+daemon off;
+
+error_log stderr;
+events { worker_connections 1024; }
+
+pid /tmp/nginx.pid;
+
+http {
+  charset utf-8;
+
+  server {
+    listen <%= ENV["PORT"] %>;
+    server_name localhost;
+    return 301 https://docs.wifi.service.gov.uk$request_uri;
+  }
+}


### PR DESCRIPTION
Currently we serve the docs from both:
docs.wifi.service.gov.uk
www.docs.wifi.service.gov.uk

Make www requests are being 301 redirected