### PR TITLE
Remove Tag Manager Implementation

### DIFF
--- a/source/javascripts/application.js
+++ b/source/javascripts/application.js
@@ -1,7 +1,1 @@
 //= require govuk_tech_docs
-
-(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-TNHHHPZ');


### PR DESCRIPTION
**WHAT:** 
This removes the current installation of Google Tag Manager in the tech docs. 

**WHY:**
This was done in preparation for the current installation of Google Analytics in the tech docs to be reconfigured.
