### PR TITLE
Update tech docs headers

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -9,8 +9,9 @@ phase: "Beta"
 
 # Links to show on right-hand-side of header
 header_links:
-  Documentation: /
-  Support: https://admin.wifi.service.gov.uk/help
+  Connect to GovWifi: https://www.wifi.service.gov.uk/about-govwifi/connect-to-govwifi
+  Offer GovWifi: https://docs.wifi.service.gov.uk/
+  Support: https://www.wifi.service.gov.uk/support
   Admin: https://admin.wifi.service.gov.uk/users/sign_in
 
 # Enables search functionality. This indexes pages only and is not recommended for single-page sites.


### PR DESCRIPTION
**IN THIS PR:**
- Add "Connect to GovWifi" link and "Offer GovWifi" link to the top navigation headers.

**BEFORE:**

<img width="1433" alt="Screenshot 2019-04-29 at 12 11 39" src="https://user-images.githubusercontent.com/32823756/56892626-1dcb6700-6a78-11e9-90c6-a12e4eeaf685.png">

------------------------------------------------------------------------------------------------------

**AFTER:**

<img width="1438" alt="Screenshot 2019-04-29 at 12 11 29" src="https://user-images.githubusercontent.com/32823756/56892632-23c14800-6a78-11e9-9f94-2c18d07574dd.png">

------------------------------------------------------------------------------------------------------

**Any feedback/suggestions would be appreciated.**