### PR TITLE
Update 'requirements' to 'offer govwifi' on Tech docs

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,6 +1,7 @@
 ---
-title: Requirements
+title: Offer GovWifi in your organisation - GovWifi
+description: Technical documentation for public sector network administrators covering how to set up and manage GovWifi in your organisation.
 weight: 1
 ---
 
-<%= partial 'documentation/requirements' %>
+<%= partial 'documentation/offer-govwifi' %>


### PR DESCRIPTION
We need to align this naming convention with what is referenced on the frontend to manage and maintain user expectations across GovWifi content