### PR TITLE
Copy only build artefacts and manifest to deploy step

### DIFF
--- a/ci/pipelines/build-and-deploy.yml
+++ b/ci/pipelines/build-and-deploy.yml
@@ -123,7 +123,7 @@ jobs:
             - name: govwifi-tech-docs
               path: repo
           outputs:
-            - name: bundled
+            - name: build
           run:
             path: sh
             dir: repo
@@ -135,9 +135,10 @@ jobs:
               apt-get install -y nodejs
               bundle install --without development
               bundle exec middleman build
-              cp -r . ../bundled/
+              cp -r build/* ../build
+              cp manifest.yml ../build
       - put: deploy-to-paas
         params:
-          manifest: bundled/manifest.yml
+          manifest: build/manifest.yml
           show_app_log: true
-          path: bundled
+          path: build


### PR DESCRIPTION
A change to cf-resource overrides path specified in manifest.yml with the path specified in the pipeline. The directory manifest.yml is copied into has been changed to reflect this. Local cf cli
commands will still work.