### PR TITLE
Link directly to poster image

### DIFF
--- a/source/documentation/set_up.md
+++ b/source/documentation/set_up.md
@@ -123,7 +123,7 @@ You should advertise GovWifi in the locations you’ll roll it out. 
 
  
 
-[Posters](https://admin.wifi.service.gov.uk/setup_instructions) are available from the admin platform with information on how end users can connect to GovWifi in your organisation.
+[Download a poster](https://admin.wifi.service.gov.uk/setup_instructions/poster) (you might need to sign in) with information on how end users can connect to GovWifi in your organisation.
 
  
 


### PR DESCRIPTION
We don’t link to it from the setup page any more, so we need to link directly to the image.

Depends on: 
- [x] https://github.com/alphagov/govwifi-admin/pull/877