### PR TITLE
fix: expose the accessibility statement

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -14,6 +14,9 @@ header_links:
   Support: https://www.wifi.service.gov.uk/support
   Admin: https://admin.wifi.service.gov.uk/users/sign_in
 
+footer_links:
+  Accessibility: https://www.wifi.service.gov.uk/accessibility-statement
+
 # Enables search functionality. This indexes pages only and is not recommended for single-page sites.
 enable_search: true
 


### PR DESCRIPTION
This adds a footer link to the accessibility statement published as part of this PR: https://github.com/alphagov/govwifi-product-page/pull/218.

This is made possible by the newly exposed `footer_links` option in the `tech-docs-gem`.