### PR TITLE
Enable LiveReload when running on Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,7 @@ COPY . .
 
 EXPOSE 4567
 
+# LiveReload
+EXPOSE 35729
+
 RUN bundle exec middleman build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,10 @@
-app:
-  build: .
-  ports:
-    - "4567:4567"
+version: "3.7"
+
+services:
+  app:
+    build: .
+    volumes:
+      - ".:/usr/src/app"
+    ports:
+      - "4567:4567"
+      - "35729:35729" # LiveReload


### PR DESCRIPTION
Because life is too short to wait for a full rebuild.