### PR TITLE
Disable GA

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -21,7 +21,7 @@ footer_links:
 enable_search: true
 
 # Tracking ID from Google Analytics (e.g. UA-XXXX-Y)
-ga_tracking_id: 'UA-127779891-1'
+# ga_tracking_id: 'UA-127779891-1'
 
 # Enable multipage navigation in the sidebar
 multipage_nav: true


### PR DESCRIPTION
This is temporary and will be enabled back once we are ready to roll out changes to cookie opt-in model in the near future.