### PR TITLE
Update 'Offer GovWifi' text 

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -11,7 +11,7 @@ phase: "Beta"
 header_links:
   Connect to GovWifi: https://www.wifi.service.gov.uk/about-govwifi/connect-to-govwifi
   Offer GovWifi: https://docs.wifi.service.gov.uk/
-  Support: https://www.wifi.service.gov.uk/support
+  Technical: https://docs.wifi.service.gov.uk/manage/#manage-govwifi
   Admin: https://admin.wifi.service.gov.uk/users/sign_in
 
 footer_links:

--- a/source/documentation/introduction.md
+++ b/source/documentation/introduction.md
@@ -1,13 +1,22 @@
 # Offer GovWifi
 
-GovWifi is a wifi authentication service using RADIUS server technology allowing staff and visitors to use a single user login to connect to guest wifi across the public sector. 
+Public sector staff and their guests often have to remember usernames and passwords for multiple wifi networks across different organisations and different office locations.
+
+GovWifi solves this problem by letting public sector staff sign up once and then use the same details to automatically connect in any building that offers GovWifi.
+
+> If you’re trying to connect a device to GovWifi, read our [sign up instructions](https://www.wifi.service.gov.uk/about-govwifi/connect-to-govwifi/).
+
+## How GovWifi works
+
+GovWifi uses RADIUS server technology to authenticate users’ usernames and passwords.
+Each end user is protected with unique credentials and encryption keys when they log in to the wifi and access the internet. These credentials are randomly generated so can’t be used to get into other systems if stolen.
+
+Users’ devices are isolated from each other to stop the horizontal spread of malware and protect secure devices from less secure ones. The network also identifies itself in a way that can’t be spoofed, adding to the safety measures that provide protection from potential attackers.
 
 If you manage IT services in a public sector organisation and would like to make GovWifi available in your buildings, use this technical documentation to find out how to:
 
-- set up GovWifi for your public sector organisation
-- manage the GovWifi connection in your buildings
-- manage your users and acceptable use of GovWifi
++ set up GovWifi for your public sector organisation
++ manage the GovWifi connection in your buildings
++ manage your users and acceptable use of GovWifi
 
-Use the left-hand navigation bar to go to different sections of the technical documentation.
-
-If you’re trying to connect a device to GovWifi, please read our [sign up instructions](https://www.wifi.service.gov.uk/about-govwifi/connect-to-govwifi/).
+The Government Digital Service operates the GovWifi service and supports public sector network administrators to set up and manage GovWifi in their organisations.

--- a/source/documentation/introduction.md
+++ b/source/documentation/introduction.md
@@ -4,7 +4,7 @@ Public sector staff and their guests often have to remember usernames and passwo
 
 GovWifi solves this problem by letting public sector staff sign up once and then use the same details to automatically connect in any building that offers GovWifi.
 
-> If you’re trying to connect a device to GovWifi, read our [sign up instructions](https://www.wifi.service.gov.uk/about-govwifi/connect-to-govwifi/).
+> If you’re trying to connect a device to GovWifi, read our [sign up instructions](https://www.wifi.service.gov.uk/connect-to-govwifi/).
 
 ## How GovWifi works
 

--- a/source/documentation/troubleshooting.md
+++ b/source/documentation/troubleshooting.md
@@ -6,15 +6,15 @@ End-user support for GovWifi is the responsibility of the relevant IT support he
 
 ## If an individual user in your organisation is having trouble connecting to GovWifi
 
-- Direct them to [our guidance on common issues](https://www.wifi.service.gov.uk/support/). 
-- [Search our logs](https://admin.wifi.service.gov.uk/logs/search/new/username) to confirm they are reaching our service 
-- Check if there are any problems with the [GovWifi service](https://status.wifi.service.gov.uk). 
+- Direct them to [our guidance on common issues](https://www.wifi.service.gov.uk/help-connecting/).
+- [Search our logs](https://admin.wifi.service.gov.uk/logs/search/new/username) to confirm they are reaching our service
+- Check if there are any problems with the [GovWifi service](https://status.wifi.service.gov.uk).
 
 
 ## If your entire organisation is having trouble connecting to GovWifi
 
-- Check your [IPs and RADIUS secret keys](https://admin.wifi.service.gov.uk/ips) match your local configuration 
-- [Search our logs](https://admin.wifi.service.gov.uk/logs/search/new/location) to confirm traffic from you is reaching our service 
-- Check if there are any problems with the [GovWifi service](https://status.wifi.service.gov.uk). 
+- Check your [IPs and RADIUS secret keys](https://admin.wifi.service.gov.uk/ips) match your local configuration
+- [Search our logs](https://admin.wifi.service.gov.uk/logs/search/new/location) to confirm traffic from you is reaching our service
+- Check if there are any problems with the [GovWifi service](https://status.wifi.service.gov.uk).
 
 If you find a problem with the central authentication service or can’t resolve an issue locally, please [contact us](https://admin.wifi.service.gov.uk/help).


### PR DESCRIPTION
This PR adds (rewritten and restructured) content from the 'Connect to GovWifi' product page - the information we think is better placed in 'Offer GovWifi'.

I won't mark it 'ready for review' until the Product Manager has ok'd it.