### PR TITLE
Add live service routes

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -4,3 +4,6 @@ applications:
     memory: 64M
     path: ./build
     buildpack: staticfile_buildpack
+    routes:
+      - route: govwifi-tech-docs.cloudapps.digital
+      - route: docs.wifi.service.gov.uk


### PR DESCRIPTION
When the deploy happens, it uses the zero downtime plugin, which needs all routes to be in the manifest, because it creates a new app.

See https://github.com/alphagov/govwifi-product-page/pull/252 for reference.