### PR TITLE
Remove race condition in concourse pipeline

### DIFF
--- a/ci/pipelines/build-and-deploy.yml
+++ b/ci/pipelines/build-and-deploy.yml
@@ -109,6 +109,7 @@ jobs:
     serial: true
     plan:
       - get: govwifi-tech-docs
+        passed: [self-update]      
         trigger: true
       - task: bundle-govwifi-tech-docs
         timeout: 15m


### PR DESCRIPTION
This ensures self-update job finishes before deploy job starts, because there could be updates to the pipeline itself which won't get picked up in case the `deploy` job starts before the `self-update` job finishes.

For context, this was first fixed for product pages here: https://github.com/alphagov/govwifi-product-page/pull/253