### PR TITLE
(Fix) Broken service link in the navigation header

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -4,7 +4,7 @@ host: docs.wifi.service.gov.uk
 # Header-related options
 show_govuk_logo: true
 service_name: GovWifi
-service_link: https://wifi.service.gov.uk
+service_link: https://www.wifi.service.gov.uk
 phase: "Beta"
 
 # Links to show on right-hand-side of header


### PR DESCRIPTION
Link to the `www` subdomain for the gov wifi product page, this resolves correctly. This is already used for other links like 'Support'.

The current link returns a `ERR_SSL_PROTOCOL_ERROR` which is likely something that can be fixed with the TLS certificates but might take longer to address.

---

**Current behaviour**

* navigate to the docs https://docs.wifi.service.gov.uk/
* click the GOV.UK GovWifi logo in the top left corner
* `ERR_SSL_PROTOCOL_ERROR`