### PR TITLE
Update accessibility statements

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -15,7 +15,8 @@ header_links:
   Admin: https://admin.wifi.service.gov.uk/users/sign_in
 
 footer_links:
-  Accessibility: https://www.wifi.service.gov.uk/accessibility-statement
+  GovWifi Website Accessibility: https://www.wifi.service.gov.uk/accessibility-statement
+  GovWifi Technical Documentation Accessibility: /accessibility.html
 
 # Enables search functionality. This indexes pages only and is not recommended for single-page sites.
 enable_search: true

--- a/source/accessibility.html.md.erb
+++ b/source/accessibility.html.md.erb
@@ -1,7 +1,84 @@
 ---
-title: Offer GovWifi in your public sector organisation
-description: Technical documentation for public sector network administrators covering how to set up and manage GovWifi in your organisation.
-weight: 1
+title: Accessibility statement for GovWifi technical documentation
+last_reviewed_on: 2020-09-21
+review_in: 6 months
+hide_in_navigation: true
 ---
 
-<%= partial 'documentation/introduction' %>
+# Accessibility statement for GovWifi technical documentation
+
+This accessibility statement applies to the GovWifi technical documentation at [https://docs.wifi.service.gov.uk/](https://docs.wifi.service.gov.uk/).
+
+This website is run by the GovWifi team at the Government Digital Service (GDS). We want as many people as possible to be able to use this website. For example, that means you should be able to:
+
++ change colours, contrast levels and fonts
++ zoom in up to 300% without problems
++ navigate most of the website using just a keyboard
++ navigate most of the website using speech recognition software
++ listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)
+
+We’ve also made the website text as simple as possible to understand.
+
+[AbilityNet](https://mcmw.abilitynet.org.uk/) has advice on making your device easier to use if you have a disability.
+
+## How accessible this website is
+
+We know some parts of this website are not fully accessible, because of issues caused by our Technical Documentation Template.
+
+## Feedback and contact information
+
+If you need any part of this service in a different format like large print, audio recording or braille, email [govwifi-support@digital.cabinet-office.gov.uk](govwifi-support@digital.cabinet-office.gov.uk).
+
+We’ll consider your request and get back to you within 2 working days.
+
+## Reporting accessibility problems with this website
+
+We’re always looking to improve the accessibility of this website. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, email [govwifi-support@digital.cabinet-office.gov.uk](govwifi-support@digital.cabinet-office.gov.uk).
+
+### Enforcement procedure
+
+The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018
+(the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, [contact the Equality Advisory and Support Service (EASS)](https://www.equalityadvisoryservice.com/).
+
+## Technical information about this website’s accessibility
+
+GDS is committed to making its website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
+
+### Compliance status
+
+This website is partially compliant with the [Web Content Accessibility Guidelines version 2.1](https://www.w3.org/TR/WCAG21/) AA standard, due to the non-compliances listed below.
+
+### Non-accessible content
+
+The content listed below is non-accessible for the following reasons.
+
+#### Non-compliance with the accessibility regulations
+
+There are parts of this documentation that are not accessible because of [issues caused by our Technical Documentation Template](https://tdt-documentation.london.cloudapps.digital/accessibility/#using-the-technical-documentation-template-for-your-own-documentation).
+
+## How we tested this website
+
+We last tested this website for accessibility issues in August 2020.
+
+We used manual and automated tests to look for issues such as:
+
+- lack of keyboard accessibility
+- link text that’s not descriptive
+- non-unique or non-hierarchical headings
+- italics, bold or block capital formatting
+- inaccessible formatting in general
+- inaccessible language
+- inaccessible diagrams or images
+- lack of colour contrast for text, important graphics and controls
+- images not having meaningful alt text
+- problems when using assistive technologies such as screen readers and screen magnifiers
+
+## What we’re doing to improve accessibility
+
+We plan to fix the issues with the Technical Documentation Template by the end of 2020.
+
+## Preparation of this accessibility statement
+
+This statement was prepared on 18 September 2020. It was last reviewed on 18 September 2020.
+
+This website was last tested in August 2020. The test was carried out by the technical writing team at GDS. We used the [WAVE Web Accessibility Evaluation Tool](https://wave.webaim.org/) and a checklist we created with the help of the GDS accessibility team. We tested a sample of pages from each section of the site.

--- a/source/accessibility.html.md.erb
+++ b/source/accessibility.html.md.erb
@@ -1,0 +1,7 @@
+---
+title: Offer GovWifi in your public sector organisation
+description: Technical documentation for public sector network administrators covering how to set up and manage GovWifi in your organisation.
+weight: 1
+---
+
+<%= partial 'documentation/introduction' %>

--- a/source/accessibility.html.md.erb
+++ b/source/accessibility.html.md.erb
@@ -79,6 +79,6 @@ We plan to fix the issues with the Technical Documentation Template by the end o
 
 ## Preparation of this accessibility statement
 
-This statement was prepared on 18 September 2020. It was last reviewed on 18 September 2020.
+This statement was prepared on 18 September 2020. It was last reviewed on 21 September 2020.
 
 This website was last tested in August 2020. The test was carried out by the technical writing team at GDS. We used the [WAVE Web Accessibility Evaluation Tool](https://wave.webaim.org/) and a checklist we created with the help of the GDS accessibility team. We tested a sample of pages from each section of the site.


### PR DESCRIPTION
### Context
The deadline for publishing an accessibility statement is 23 September 2020. The GovWifi technical documentation does not have a dedicated statement published although there is one for the website. 

### Changes proposed in this pull request
Add an accessibility statement for tech docs with information from the August 2020 accessibility audit. Include a link in the bottom navigation to the accessibility statements for the GovWifi website and tech docs. Please note there is a separate statement on the tech doc template itself, which is being handled as part of a separate project.