### PR TITLE
Add Docker Hub auth token to build-deployable

### DIFF
--- a/ci/pipelines/build-and-deploy.yml
+++ b/ci/pipelines/build-and-deploy.yml
@@ -14,6 +14,8 @@ resource_types:
   type: registry-image
   source:
     repository: teliaoss/github-pr-resource
+    username: ((docker_hub_username))
+    password: ((docker_hub_authtoken))
 
 resources:
   - name: tech-ops
@@ -81,6 +83,8 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/cf-cli
+              username: ((docker_hub_username))
+              password: ((docker_hub_authtoken))
             version: {digest: "sha256:524554e6bcd9e77e9f3886de0ee2c1307976361a41a009b4690c709afd52812e"}
           inputs:
             - name: govwifi-tech-docs-pr
@@ -109,7 +113,7 @@ jobs:
     serial: true
     plan:
       - get: govwifi-tech-docs
-        passed: [self-update]      
+        passed: [self-update]
         trigger: true
       - task: bundle-govwifi-tech-docs
         timeout: 15m
@@ -119,6 +123,8 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/cf-cli
+              username: ((docker_hub_username))
+              password: ((docker_hub_authtoken))
             version: {digest: "sha256:524554e6bcd9e77e9f3886de0ee2c1307976361a41a009b4690c709afd52812e"}
           inputs:
             - name: govwifi-tech-docs


### PR DESCRIPTION
Add Docker Hub auth token to allow Concourse pipeline task to pull images from Docker Hub.

We need to do this because Docker Hub will introduce rate limiting on 1 November.

paired: @camdesgov & @sarahseewhy