### PR TITLE
Update links to product site

### DIFF
--- a/source/documentation/introduction.md
+++ b/source/documentation/introduction.md
@@ -4,7 +4,7 @@ Public sector staff and their guests often have to remember different usernames 
 
 GovWifi solves this problem. Public sector staff sign up once and connect their device using their unique details. They’ll then automatically connect to GovWifi in any building that offers it.
 
-If you’re trying to connect a device to GovWifi, read our [sign up instructions](https://www.wifi.service.gov.uk/about-govwifi/connect-to-govwifi/).
+If you’re trying to connect a device to GovWifi, read our [sign up instructions](https://www.wifi.service.gov.uk/connect-to-govwifi/).
 
 ## How GovWifi works
 


### PR DESCRIPTION
We recently restructured the product site alongside adding the text number. This update is to use the new URLs.