### PR TITLE
Add content about business continuity planning

### DIFF
--- a/source/documentation/manage.md
+++ b/source/documentation/manage.md
@@ -7,6 +7,36 @@ This guidance explains how to manage GovWifi for your organisation once you've i
 
 After you’ve successfully deployed GovWifi, you can remove less secure guest wifi services.
 
+## Create a plan to deal with a GovWifi outage 
+
+If GovWifi is critical for your organisation, create a business continuity plan so you can still provide internet access in your buildings if there’s a problem with GovWifi. 
+
+We should be able to resolve most incidents within a few hours. However, in the unlikely event that there’s a catastrophic failure of our infrastructure, it could take up to 2 weeks to restore the service.
+
+Consult with your risk assessment and technology teams on your business continuity plan. 
+
+### Set up a backup SSID
+
+We recommend you have a backup guest SSID that people in your buildings can use if there’s a long GovWifi outage. 
+
+When setting up your backup guest SSID: 
+- make sure it meets our [security standards](https://docs.wifi.service.gov.uk/requirements/#security), and points users to any terms of use your organisation has 
+- do not use ‘GovWifi’ as the SSID, or you might have potential conflicts when GovWifi is working again 
+- make sure you can easily disable it when GovWifi is working again 
+
+Run regular tests of the SSID to make sure you can quickly switch to it if required.
+
+### Document how to update the GovWifi configuration 
+
+If GovWifi is going to be down for a long time, we might ask you to update your GovWifi configuration with temporary IP addresses for our RADIUS servers. 
+
+Make sure you’ve documented how to update the GovWifi configuration at your site so you can do this if necessary.
+
+### Plan how you'll tell your users 
+
+Plan how you’ll tell your users to use the backup SSID. Make sure your users on managed devices will be able to connect to the backup SSIDs created by each building if they’re roaming.
+
+Share the relevant parts of your business continuity plan with your user support team so they know how to help users.
 
 ## View and update your site configuration
 

--- a/source/documentation/manage.md
+++ b/source/documentation/manage.md
@@ -2,11 +2,6 @@
 
 This guidance explains how to manage GovWifi for your organisation once you've installed it.
 
-
-## Withdraw legacy services
-
-After you’ve successfully deployed GovWifi, you can remove less secure guest wifi services.
-
 ## Create a plan to deal with a GovWifi outage 
 
 If GovWifi is critical for your organisation, create a business continuity plan so you can still provide internet access in your buildings if there’s a problem with GovWifi. 
@@ -20,6 +15,7 @@ Consult with your risk assessment and technology teams on your business continui
 We recommend you have a backup guest SSID that people in your buildings can use if there’s a long GovWifi outage. 
 
 When setting up your backup guest SSID: 
+
 - make sure it meets our [security standards](https://docs.wifi.service.gov.uk/requirements/#security), and points users to any terms of use your organisation has 
 - do not use ‘GovWifi’ as the SSID, or you might have potential conflicts when GovWifi is working again 
 - make sure you can easily disable it when GovWifi is working again 


### PR DESCRIPTION
### What
Added content that tells organisations to have a plan in case GovWifi is offline for a long time. 

### Why
So there's minimal disruption to end users if there's a severe incident. 

Trello card: https://trello.com/c/fJRlKLBB/1480-add-bcp-requirement-to-tech-docs
