### PR TITLE
Remove "we plan to fix" text left in accessibility statement

### DIFF
--- a/source/accessibility.html.md.erb
+++ b/source/accessibility.html.md.erb
@@ -73,10 +73,6 @@ DAC also tested to make sure that the service can be used:
 * without a mouse
 * by disabled people who do not use specific assistive technology
 
-## What we’re doing to improve accessibility
-
-We plan to fix the issues with the Technical Documentation Template by the end of March 2021.
-
 ## Preparation of this accessibility statement
 
 This statement was prepared on 18 September 2020. It was last reviewed on 25 August 2021.


### PR DESCRIPTION
### What
Remove "we plan to fix" text left in accessibility statement

### Why
This was missed in previous change. As we are not responsible for the template, we should not make a statement on when we plan to fix.
