### PR TITLE
Remove 'Beta' phase banner

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -5,7 +5,6 @@ host: docs.wifi.service.gov.uk
 show_govuk_logo: true
 service_name: GovWifi
 service_link: https://wifi.service.gov.uk
-phase: "Beta"
 
 # Links to show on right-hand-side of header
 header_links:


### PR DESCRIPTION
### What

Remove 'Beta' phase banner

### Why

GovWifi is now a live service and live services do not require a phase banner on their sites. The phase banner is generated from the `tech-docs` "phase" key, removing it here removes it from all the `erb` files.

See tech-docs gem documentation for more details: https://tdt-documentation.london.cloudapps.digital/configure_project/global_configuration/#configure-your-documentation-site

Link to Trello card (if applicable):  https://trello.com/c/xNubBHd2/1647-remove-beta-label
