### PR TITLE
Bump `govwifi-shared-frontend`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,49 @@
 {
   "name": "govwifi-tech-docs",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "govwifi-tech-docs",
+      "version": "1.0.0",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "govuk-frontend": "^3.5.0",
+        "govwifi-shared-frontend": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.8/govwifi-shared-frontend-0.6.8.tgz"
+      }
+    },
+    "node_modules/govuk-frontend": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.5.0.tgz",
+      "integrity": "sha512-4tNKgcChO1bMNsrTz2UsK4fDMmU9R87UDxy/KhKIMbnhsuJLVuArDveYLkZuUsZ6B3eaCbl5gmI8i/Q/Mi680A==",
+      "engines": {
+        "node": ">= 4.2.0"
+      }
+    },
+    "node_modules/govwifi-shared-frontend": {
+      "version": "0.6.8",
+      "resolved": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.8/govwifi-shared-frontend-0.6.8.tgz",
+      "integrity": "sha512-T+v5yq2oDOhqKfGUCxsiLmvU3mBrgFHGUo6x+D6+66KOLTj9YEWBgQoh/xl5W0qc3IKMyBONB2FhzEXttslgkA==",
+      "license": "MIT",
+      "dependencies": {
+        "js-cookie": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=12.13.0",
+        "npm": ">=8.4.1"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
+      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==",
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  },
   "dependencies": {
     "govuk-frontend": {
       "version": "3.5.0",
@@ -10,8 +51,8 @@
       "integrity": "sha512-4tNKgcChO1bMNsrTz2UsK4fDMmU9R87UDxy/KhKIMbnhsuJLVuArDveYLkZuUsZ6B3eaCbl5gmI8i/Q/Mi680A=="
     },
     "govwifi-shared-frontend": {
-      "version": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.7/govwifi-shared-frontend-0.6.7.tgz",
-      "integrity": "sha512-9m+5a7PmfOL2dHQfdAeynH2xEfoiREC2g5af5KmgCLLwqCEkDnLhXKwVkE0zl84d0X/nODbbseYKVnLTY45vzQ==",
+      "version": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.8/govwifi-shared-frontend-0.6.8.tgz",
+      "integrity": "sha512-T+v5yq2oDOhqKfGUCxsiLmvU3mBrgFHGUo6x+D6+66KOLTj9YEWBgQoh/xl5W0qc3IKMyBONB2FhzEXttslgkA==",
       "requires": {
         "js-cookie": "^3.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/alphagov/govwifi-tech-docs#readme",
   "dependencies": {
     "govuk-frontend": "^3.5.0",
-    "govwifi-shared-frontend": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.7/govwifi-shared-frontend-0.6.7.tgz"
+    "govwifi-shared-frontend": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.8/govwifi-shared-frontend-0.6.8.tgz"
   },
   "scripts": {
     "install": "./copy-assets.rb"


### PR DESCRIPTION
### What

Bump the release version to `0.6.8` to match what's in GitHub.

### Why

There's a new release of `govwifi-shared-frontend` (see [here](https://github.com/alphagov/govwifi-shared-frontend/releases/tag/v0.6.8)), we need to be keeping up with the changes.
