### PR TITLE
Update govwifi-shared-frontend package SHA

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
     },
     "govwifi-shared-frontend": {
       "version": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.7/govwifi-shared-frontend-0.6.7.tgz",
-      "integrity": "sha512-9m+5a7PmfOL2dHQfdAeynH2xEfoiREC2g5af5KmgCLLwqCEkDnLhXKwVkE0zl84d0X/nODbbseYKVnLTY45vzQ==",
+      "integrity": "sha512-zRLQos9r+iVPDl1OzyKTaL1d3v4kGd3lAUsMWS/svbcx6dBzFGmXSpxBr1JZezK5lViuHAOtUIe+cpuI2zytfQ==",
       "requires": {
         "js-cookie": "^3.0.1"
       }


### PR DESCRIPTION
### What
Update version of govwifi-shared-frontend referenced

### Why
Using an earlier version (0.6.7) seems to be causing a error when we attempt to
deploy this with Concourse.


