### PR TITLE
Replace the nodejs-npm with npm - package name has changed in alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /usr/src/app
 
 COPY Gemfile Gemfile.lock .ruby-version ./
 
-RUN apk --update add g++ musl-dev make git nodejs nodejs-npm
+RUN apk --update add g++ musl-dev make git nodejs npm
 RUN bundle install
 COPY . .
 


### PR DESCRIPTION

### What
Change the package name from nodejs-npm to npm

### Why
The above package name has changed in the alpine image


Link to Trello card (if applicable): n/a
