### PR TITLE
Create build and deploy actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,65 @@
+name: Deploy
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+
+  build_and_deploy_tech_docs:
+    environment: production
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 'latest'
+
+      - name: Setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Install ruby dependencies
+        run: bundle install
+
+      - name: Install node modules
+        run: npm install
+
+      - name: Build static site
+        run: bundle exec middleman build
+
+      - name: Install CF CLI
+        run: |
+          wget https://s3-us-west-1.amazonaws.com/v7-cf-cli-releases/releases/v7.2.0/cf7-cli-installer_7.2.0_x86-64.deb
+          sudo dpkg -i cf7-cli-installer_7.2.0_x86-64.deb
+
+      - name: Authenticate with Gov.UK PaaS
+        env:
+          CF_API: "https://api.cloud.service.gov.uk"
+          CF_ORG: "govwifi"
+          CF_SPACE: "production"
+          CF_USERNAME: ${{ secrets.cf_username }}
+          CF_PASSWORD: ${{ secrets.cf_password }}
+        run: |
+          echo "Logging into $CF_ORG/$CF_SPACE..."
+          cf api "${CF_API}"
+          cf auth
+          cf target -o "${CF_ORG}" -s "${CF_SPACE}"
+
+      - name: Deploy to Gov.UK PaaS
+        env:
+          CF_API: "https://api.cloud.service.gov.uk"
+          CF_ORG: "govwifi"
+          CF_SPACE: "production"
+          CF_USERNAME: ${{ secrets.cf_username }}
+          CF_PASSWORD: ${{ secrets.cf_password }}
+        run: |
+          cf push --strategy rolling -f manifest.yml
+          cf logout
+          


### PR DESCRIPTION
### What
This PR will introduce a Github action to build and deploy our Tech Docs to PaaS, Govwifi space.

### Why
We are migrating this task away from our hosted in AWS Concourse to save taxpayer funds.

### Link to Trello card 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-434

### Testing
The workflow can be re-run in Github. It will build and deploy to PaaS Govwifi sandbox. This would need to be removed using cf delete [application] when testing is complete.