### PR TITLE
Remove H2 from connect for individual use section

### DIFF
--- a/source/documentation/set_up.md
+++ b/source/documentation/set_up.md
@@ -9,10 +9,6 @@
 
 After creating your account you should invite at least one colleague to create an account. This is so they can reset your two-factor authentication, if needed. Invite them from the ‘team members’ section of GovWifi admin.
 
-## Connect to GovWifi for individual use
-
-Follow the instructions to [create a GovWifi account and connect to GovWifi](https://www.wifi.service.gov.uk/connect-to-govwifi/).
-
 ## Sign the memorandum of understanding
 
 You must [sign the memorandum of understanding](https://admin.wifi.service.gov.uk/mou) (MOU) before your organisation can begin installing GovWifi.


### PR DESCRIPTION
H2 removed from Connect to GovWifi for individual use section. This is to prevent 'Connect for individual use' appearing in the navigation within 'setup GovWifi for your organisation'.

### What
With the content changes now actioned 'Connect for individual use' is appearing as a navigation item from the H2. This change removes the H2 and means 'Connect for invididual use' doesn't appear in the navigation.

### Why
Connect to GovWifi for individual use shouldn't be a navigation item within 'Setup GovWifi for your organisation'. That could be confusing. The intention of the content changes is only to alert individual users landing on this section that they are in the wrong place.
