### PR TITLE
GW-471 Remove --unsafe-perm from npm call

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,6 @@ EXPOSE 4567
 # LiveReload
 EXPOSE 35729
 
-RUN npm install --unsafe-perm
+# RUN npm install --unsafe-perm
+RUN npm install
 RUN bundle exec middleman build

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,44 @@
 {
   "name": "govwifi-tech-docs",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "govwifi-tech-docs",
+      "version": "1.0.0",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "govuk-frontend": "^3.5.0",
+        "govwifi-shared-frontend": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.7/govwifi-shared-frontend-0.6.7.tgz"
+      }
+    },
+    "node_modules/govuk-frontend": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.5.0.tgz",
+      "integrity": "sha512-4tNKgcChO1bMNsrTz2UsK4fDMmU9R87UDxy/KhKIMbnhsuJLVuArDveYLkZuUsZ6B3eaCbl5gmI8i/Q/Mi680A==",
+      "engines": {
+        "node": ">= 4.2.0"
+      }
+    },
+    "node_modules/govwifi-shared-frontend": {
+      "version": "0.6.7",
+      "resolved": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.7/govwifi-shared-frontend-0.6.7.tgz",
+      "integrity": "sha512-zRLQos9r+iVPDl1OzyKTaL1d3v4kGd3lAUsMWS/svbcx6dBzFGmXSpxBr1JZezK5lViuHAOtUIe+cpuI2zytfQ==",
+      "dependencies": {
+        "js-cookie": "^3.0.1"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
+      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==",
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  },
   "dependencies": {
     "govuk-frontend": {
       "version": "3.5.0",


### PR DESCRIPTION
### What
Describe the change
Fix console javascript errors when App is created via 'make serve'

### Why
Describe why the change was necessary
Fix Errors.

Link to Trello card (if applicable): 
https://technologyprogramme.atlassian.net/browse/GW-471
