### PR TITLE
Update link for search the logs

### DIFF
--- a/source/documentation/troubleshooting.md
+++ b/source/documentation/troubleshooting.md
@@ -13,7 +13,7 @@ If you've already set up GovWifi, you can follow these steps to try and resolve 
 GovWifi administrators:
 
 - [check your IP addresses and RADIUS secret keys](https://admin.wifi.service.gov.uk/ips) match your local configuration
-- [search the logs](https://admin.wifi.service.gov.uk/logs/search/new/location) to confirm traffic from your organisation is reaching the service
+- [search the logs](https://admin.wifi.service.gov.uk/users/sign_in) to confirm traffic from your organisation is reaching the service
 
 ## Troubleshooting to support individual users
 


### PR DESCRIPTION
### What
Search the logs for admins was using an outdated (broken) link. Now updated to correct location.

### Why
Broken link in tech docs.

### Jira
https://technologyprogramme.atlassian.net/jira/software/projects/DDJTS/boards/251?assignee=628b458a40b157006f721ef5&selectedIssue=GW-608
