### PR TITLE
Text changes for prioritise GovWifi profile

### DIFF
--- a/source/documentation/set_up.md
+++ b/source/documentation/set_up.md
@@ -84,7 +84,7 @@ Read about how to [create certificate profiles in configuration manager](https:/
 
 ### Prioritise the GovWifi profile
 
-GovWifi must be the highest priority service set identifier (SSID) in your organisation, except for SSIDs that provide access to privileged networks using device certificates.
+GovWifi should be set as the highest priority service set identifier (SSID) in your organisation. This does not apply when internal SSIDs are providing access to privileged networks using certificate based authentication.
 
 Add the following to your users’ login script:
 


### PR DESCRIPTION
### What
Text changes to make 'prioritise GovWifi profile' section of tech docs an optional step.

### Why
Prioritising the GovWifi profile depends on the organisation - it's not a mandatory step for all admins.

### Jira
https://technologyprogramme.atlassian.net/jira/software/projects/DDJTS/boards/251?assignee=628b458a40b157006f721ef5&selectedIssue=GW-790

