### PR TITLE
Update cert rotation tech doc for 2023

### DIFF
--- a/source/documentation/certificate-rotation.md
+++ b/source/documentation/certificate-rotation.md
@@ -2,7 +2,7 @@
 
 Every year, we rotate the GovWifi server certificate. Occasionally, we’ll also need to replace the intermediate or root certificates. This is an industry standard procedure that keeps the authentication process secure.
 
-We’ll give you at least one month’s notice about certificate rotations. The next one is scheduled for 31 May 2023.
+We’ll give you at least one month’s notice about certificate rotations. The next one is scheduled for Thursday 25 May 2023.
 
 The GovWifi team carries out the certificate rotation on the RADIUS servers, but your organisation may need to do some work to make sure your users can connect to GovWifi after the rotation.
 
@@ -13,15 +13,15 @@ You do not need to do anything to your access points, wifi controllers or any ot
 This section applies to you if your organisation does both of the following:
 
 * deploys the GovWifi 802.1x profile
-* tells user devices to check the ‘server’ certificate (currently wifi.service.gov.uk) or intermediate certificate (currently GeoTrust TLS DV RSA Mixed SHA256 2020 CA-1)
+* tells user devices to check the ‘server’ certificate (currently wifi.service.gov.uk) or intermediate certificate (currently GeoTrust TLS RSA CA G1) or root certificate (currently DigiCert Global Root G2)
 
 If you need to update the profile with the new certificate details you must push the updated profile out to your managed devices. How you manage this will depend on how you deploy your GovWifi 802.1x profile to your managed devices.
 
-Download the 2022 certificate:
+Download the new certificates for 2023:
 
-- [server certificate](https://docs.wifi.service.gov.uk/assets/2022/wifi.service.gov.uk.crt)
-
-The [root certificate](https://docs.wifi.service.gov.uk/assets/2022/DigiCertGlobalRootCA.crt) and [intermediate certificate](https://docs.wifi.service.gov.uk/assets/2022/GeoTrustRSACA.crt) will not change in 2022. This means you do not need to update your 802.1x profile if it only checks the root certificate.
+* [server certificate](https://docs.wifi.service.gov.uk/assets/2023/wifi.service.gov.uk.crt)
+* [intermediate certificate](https://docs.wifi.service.gov.uk/assets/2023/GeoTrustTLSRSACAG1.crt)
+* [root certificate](https://docs.wifi.service.gov.uk/assets/2023/DigiCertGlobalRootG2.crt)
 
 ## Help users accept the new certificate
 
@@ -39,8 +39,8 @@ They should:
 
 1. View the certificate.
 1. Check that the domain is **wifi.service.gov.uk**
-1. Check the issuer is **GeoTrust TLS DV RSA Mixed SHA256 2020 CA-1**
-1. Check that the fingerprint or thumbprint is **2A A4 70 43 4F 33 81 5C F7 C4 F7 85 60 46 52 27 F1 AD C9 6A**
+1. Check the issuer is **GeoTrust TLS RSA CA G1**
+1. Check that the fingerprint or thumbprint is **3F 8B B7 3C FD F7 50 36 7F 43 10 33 67 40 7A FA 2E 6E E5 D6**
 1. Accept or trust the new certificate.
 
 Depending on their device, they may not be able to see all the information referred to here.


### PR DESCRIPTION
### What
Updated cert rotation copy: new links to certs, refs to 2022 updated to 2023.

### Why
Bring cert rotation 


### Jira
https://technologyprogramme.atlassian.net/jira/software/projects/DDJTS/boards/251?assignee=628b458a40b157006f721ef5&selectedIssue=GW-824
