### PR TITLE
Update a cert rotation guidance for Admins.

### DIFF
--- a/source/documentation/certificate-rotation.md
+++ b/source/documentation/certificate-rotation.md
@@ -25,7 +25,7 @@ The [root certificate](https://docs.wifi.service.gov.uk/assets/2022/DigiCertGlob
 
 ## Help users accept the new certificate
 
-We’ve published [guidance for users](https://www.wifi.service.gov.uk/connect-to-govwifi/update-govwifi-server-certificate/) on what to do and we’ll tell them about the update in advance. However, they may still need help from your IT support team.
+We’ve published [guidance for users](https://www.wifi.service.gov.uk/connect-to-govwifi/update-govwifi-server-certificate/) on what to do. However, they may still need help from your IT support team.
 
 ### What they need to do may vary
 


### PR DESCRIPTION
### What
We want to ensure our Tech Doc guidance is in line with comms emailed to the users.

### Why
We need to ensure all docs are up to date before cert rotation.

Link to Trello card (if applicable): 
