### PR TITLE
Remove network access server points text from documentation

### DIFF
--- a/source/documentation/set_up.md
+++ b/source/documentation/set_up.md
@@ -40,10 +40,6 @@ We recommend connecting to all GovWifi RADIUS servers, so you're protected from 
 
 > Make sure you spell GovWifi exactly as shown. Do not use a variation like 'Govwifi' or 'GovWiFi'. If different GovWifi networks format the SSID differently, users will have to authenticate to each one rather than connecting automatically. Their devices will not recognise them as the same network.
 
-3. Configure your Network Access Server (access point) to make usernames private.
-4. If allowed by your infrastructure vendor, set the Network Access Identifier (NAI) for your outer tunnel to be
-anonymous. See [RFC 7542](https://tools.ietf.org/html/rfc7542) for full details of permitted NAI syntax.
-
 ## Set up managed end user devices
 
 Users must follow the [GovWifi terms and conditions](https://www.gov.uk/government/publications/terms-and-conditions-for-connecting-to-govwifi/terms-and-conditions-for-connecting-to-govwifi) for managed and unmanaged devices.


### PR DESCRIPTION
### What
This text:

Configure your Network Access Server (access point) to make usernames private.
If allowed by your infrastructure vendor, set the Network Access Identifier (NAI) for your outer tunnel to be anonymous. See [RFC 7542](https://tools.ietf.org/html/rfc7542) for full details of permitted NAI syntax.

is removed from the documentation in this PR.

### Why
For accuracy, see more detail in GW-860.

### Jira
[Jira ticket: ](https://technologyprogramme.atlassian.net/jira/software/projects/DDJTS/boards/251?assignee=628b458a40b157006f721ef5&selectedIssue=GW-860)
