### PR TITLE
Gw 1266 fix broken links

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,4 +5,5 @@ Describe the change
 Describe why the change was necessary
 
 
-Link to Trello card (if applicable): 
+### Link to Jira card (if applicable): 
+[GW-xxxx](https://technologyprogramme.atlassian.net/browse/GW-xxxx)

--- a/README.md
+++ b/README.md
@@ -96,11 +96,11 @@ the HTML and asset files ready to be published.
 3. Make your changes (with tests if applicable)
 4. Raise a pull request
 
-## Licence
+## License
 
 The documentation is [© Crown copyright][copyright] and available under the terms
-of the [Open Government 3.0][ogl] licence.
+of the [Open Government 3.0][ogl] license.
 
-[mit]: LICENCE
+[mit]: LICENSE
 [copyright]: http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/
 [ogl]: http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/

--- a/config.rb
+++ b/config.rb
@@ -11,3 +11,6 @@ configure :build do
 end
 
 GovukTechDocs.configure(self)
+
+redirect "set_up/index.html", to: "/set_up.html"
+redirect "requirements/index.html", to: "/requirements.html"

--- a/source/documentation/certificate-rotation.md
+++ b/source/documentation/certificate-rotation.md
@@ -25,7 +25,7 @@ Download the new certificates for 2023:
 
 ## Help users accept the new certificate
 
-We’ve published [guidance for users](https://www.wifi.service.gov.uk/connect-to-govwifi/update-govwifi-server-certificate/) on what to do. However, they may still need help from your IT support team.
+We’ve published [guidance for users](https://www.wifi.service.gov.uk/update-govwifi-server-certificate/) on what to do. However, they may still need help from your IT support team.
 
 ### What they need to do may vary
 
@@ -58,7 +58,7 @@ Depending how a user's organisation deploys the profile, user’s may need to co
 If the user has accepted the certificate but still cannot connect, follow your usual troubleshooting process. You can also advise them to:
 
 - forget the network and try to connect again
-- follow our [guidance on common issues with GovWifi](https://www.wifi.service.gov.uk/connect-to-govwifi/get-help-connecting/)
+- follow our [guidance on common issues with GovWifi](https://www.wifi.service.gov.uk/get-help-connecting/)
 
 ## Get support
 

--- a/source/documentation/manage.md
+++ b/source/documentation/manage.md
@@ -14,7 +14,7 @@ You can [use our poster](/assets/GovWifi-poster.png). It includes information on
 
 ## Support GovWifi users in your buildings
 
-While we provide [support information for users](https://www.wifi.service.gov.uk/connect-to-govwifi/get-help-connecting/) on our GovWifi site, your organisation must support GovWifi users who cannot solve their own issues. 
+While we provide [support information for users](https://www.wifi.service.gov.uk/get-help-connecting/) on our GovWifi site, your organisation must support GovWifi users who cannot solve their own issues. 
 
 You can decide how to do this. The only requirement is that users have a clear route to a human who can help them. This may be an email address or phone number included on your GovWifi advertisements.  
 

--- a/source/documentation/requirements.md
+++ b/source/documentation/requirements.md
@@ -58,4 +58,4 @@ Use automatic channel selection features in enterprise wifi management systems r
 
 After checking that your existing wifi setup can support GovWifi you can continue to:
 
-- [setup GovWifi for your organisation](https://docs.wifi.service.gov.uk/set_up)
+- [setup GovWifi for your organisation](./set_up)

--- a/source/documentation/set_up.md
+++ b/source/documentation/set_up.md
@@ -1,4 +1,4 @@
-Before offering GovWifi in your organisation check that [your existing wifi setup can support it](https://docs.wifi.service.gov.uk/requirements/).
+Before offering GovWifi in your organisation check that [your existing wifi setup can support it](./requirements/).
 
 # Set up GovWifi for your organisation
 
@@ -6,7 +6,7 @@ Before offering GovWifi in your organisation check that [your existing wifi setu
 
 > To connect to GovWifi for individual use, follow the instructions to [create a GovWifi account and connect to GovWifi](https://www.wifi.service.gov.uk/connect-to-govwifi/).
 
-1. Check if [GovWifi is available to your organisation](https://www.wifi.service.gov.uk/connect-to-govwifi/organisations-using-govwifi/). If your organisation is not listed [contact us](https://admin.wifi.service.gov.uk/help/new/technical_support).
+1. Check if [GovWifi is available to your organisation](https://www.wifi.service.gov.uk/organisations-using-govwifi/). If your organisation is not listed [contact us](https://admin.wifi.service.gov.uk/help/new/technical_support).
 2. [Sign up for a GovWifi administrator account](https://admin.wifi.service.gov.uk/users/sign_up).
 
 After creating your account you should invite at least one colleague to create an account. This is so that a colleague can reset your two-factor authentication, if needed. Invite them from the **team members** section of your GovWifi admin account.
@@ -15,7 +15,7 @@ After creating your account you should invite at least one colleague to create a
 
 You must [sign the memorandum of understanding](https://admin.wifi.service.gov.uk/mou) (MOU) before your organisation can begin installing GovWifi.
 
-The MOU sets out the agreement between the Government Digital Service (GDS) and your public sector organisation in relation to GovWifi use. You can find the digital version of the MOU [here.](/mou)
+The MOU sets out the agreement between the Government Digital Service (GDS) and your public sector organisation in relation to GovWifi use. You can [find the digital version of the MO here.](./mou)
 
 ## Create a new wifi installation
 
@@ -116,7 +116,7 @@ We recommend you have a backup guest SSID that people in your buildings can use 
 
 When setting up your backup guest SSID: 
 
-- make sure it meets our [security standards](https://docs.wifi.service.gov.uk/requirements/#security), and points users to any terms of use your organisation has 
+- make sure it meets our [security standards](./requirements.html#secure-your-network), and points users to any terms of use your organisation has 
 - do not use ‘GovWifi’ as the SSID, or you might have potential conflicts when GovWifi is working again 
 - make sure you can easily disable it when GovWifi is working again 
 

--- a/source/documentation/set_up.md
+++ b/source/documentation/set_up.md
@@ -15,7 +15,7 @@ After creating your account you should invite at least one colleague to create a
 
 You must [sign the memorandum of understanding](https://admin.wifi.service.gov.uk/mou) (MOU) before your organisation can begin installing GovWifi.
 
-The MOU sets out the agreement between the Government Digital Service (GDS) and your public sector organisation in relation to GovWifi use. You can [find the digital version of the MO here.](./mou)
+The MOU sets out the agreement between the Government Digital Service (GDS) and your public sector organisation in relation to GovWifi use. You can [find the digital version of the MOU here.](./mou)
 
 ## Create a new wifi installation
 

--- a/source/documentation/troubleshooting.md
+++ b/source/documentation/troubleshooting.md
@@ -19,7 +19,7 @@ GovWifi administrators:
 
 Issues like slow speeds, dropped connections, or difficulty accessing certain sites, are related to the local network. GovWifi is an authentication service and GovWifi support cannot help with these.
 
-You can check that users have followed the [guidance on common issues](https://www.wifi.service.gov.uk/connect-to-govwifi/get-help-connecting/). You can also use the guidance on how to [create an account and connect a device to GovWifi](https://www.wifi.service.gov.uk/connect-to-govwifi/).
+You can check that users have followed the [guidance on common issues](https://www.wifi.service.gov.uk/get-help-connecting/). You can also use the guidance on how to [create an account and connect a device to GovWifi](https://www.wifi.service.gov.uk/connect-to-govwifi/).
 
 ### Sponsor the user for new sign-up details
 


### PR DESCRIPTION
### What
Update broken links due to migration

### Why
So that the pages can be found.


Link to Jira card (if applicable): 
[GW-1266](https://technologyprogramme.atlassian.net/browse/GW-1266)


[GW-1266]: https://technologyprogramme.atlassian.net/browse/GW-1266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ