### PR TITLE
A change to reflect a certificate rotation date for 2024.

### DIFF
--- a/source/documentation/certificate-rotation.md
+++ b/source/documentation/certificate-rotation.md
@@ -2,7 +2,7 @@
 
 Every year, we rotate the GovWifi server certificate. Occasionally, we’ll also need to replace the intermediate or root certificates. This is an industry standard procedure that keeps the authentication process secure.
 
-We’ll give you at least one month’s notice about certificate rotations. The next one is scheduled for Thursday 25 May 2023.
+We’ll give you at least one month’s notice about certificate rotations. The next one is scheduled for Thursday 23 May 2024.
 
 The GovWifi team carries out the certificate rotation on the RADIUS servers, but your organisation may need to do some work to make sure your users can connect to GovWifi after the rotation.
 


### PR DESCRIPTION
### What
Certificate date is using 2023 date.

### Why
We have the new date for 2024 agreed already.
