### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/default-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/default-issue-template.md
@@ -1,0 +1,12 @@
+---
+name: default issue template
+about: A custom template for tech docs
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Please Note:** this is *not* a support channel, if you are experiencing problems with GovWifi please contact your Network Administrators who can raise a ticket with us via the Admin Portal. thank you.
+
+Please raise an issue if the documentation is incorrect, links do not work or if you feel that there is missing information.


### PR DESCRIPTION
Using a default template, try and direct people to the correct support channel, as this isn't monitored for support.