### PR TITLE
fix: [GW-1729] [GW-1646] Update github actions.

### DIFF
--- a/.github/workflows/build-tech-docs.yml
+++ b/.github/workflows/build-tech-docs.yml
@@ -1,0 +1,29 @@
+name: build-on-pr
+on: [pull_request]
+jobs:
+
+    build_tech_docs:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v4
+          with:
+            fetch-depth: 0
+  
+        - name: Setup node
+          uses: actions/setup-node@v4
+          with:
+            node-version: 'latest'
+  
+        - name: Setup ruby
+          uses: ruby/setup-ruby@v1
+          with:
+            bundler-cache: true
+
+        - name: Setup npm
+          run: npm install
+
+        - name: Install ruby dependencies
+          run: bundle install
+
+        - name: Build static site
+          run: bundle exec middleman build

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 'latest'
 
@@ -34,7 +34,7 @@ jobs:
         run: bundle exec middleman build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./build
           
@@ -54,4 +54,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
### What
Update github actions, add action to check for building the project on raise of PR.

### Why
Security, reliability, some actions were being deprecated, and the build/check action will give confidence the dependabot wont break anything :)


### Link to Jira card (if applicable): 
[GW-1646](https://technologyprogramme.atlassian.net/browse/GW-1676)
[GW-1729](https://technologyprogramme.atlassian.net/browse/GW-1729)

[GW-1646]: https://technologyprogramme.atlassian.net/browse/GW-1646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GW-1729]: https://technologyprogramme.atlassian.net/browse/GW-1729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ