### PR TITLE
Add config file to prevent blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
### What
Add config file to prevent issues being raised without using a template.

### Why
So that support issues can be directed in the correct channel.
