### PR TITLE
Add ignore rule for Ruby dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,6 @@ updates:
       interval: daily
       time: "03:00"
     open-pull-requests-limit: 10
+    # Ignore updates to Ruby as this will be handled by the ruby-updater workflow.
+    ignore:
+    - dependency-name: ruby


### PR DESCRIPTION
### What
Ignore Ruby from Dependabots

### Why
Because it fails, creates noise and we now have a workflow to handle this, that works.


### Link to Jira card (if applicable): 
n/a
