### PR TITLE
Bump govwifi-shared-frontend to 0.6.26

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "govuk-frontend": "^6.0.0",
-        "govwifi-shared-frontend": "https://github.com/GovWifi/govwifi-shared-frontend/releases/download/v0.6.21/govwifi-shared-frontend-0.6.21.tgz"
+        "govwifi-shared-frontend": "https://github.com/GovWifi/govwifi-shared-frontend/releases/download/v0.6.26/govwifi-shared-frontend-0.6.26.tgz"
       }
     },
     "node_modules/govuk-frontend": {
@@ -24,12 +24,12 @@
       }
     },
     "node_modules/govwifi-shared-frontend": {
-      "version": "0.6.21",
-      "resolved": "https://github.com/GovWifi/govwifi-shared-frontend/releases/download/v0.6.21/govwifi-shared-frontend-0.6.21.tgz",
-      "integrity": "sha512-EDpJt9Hs9YC1Ee52uPrQlPI8/pzUSh/mXVfBAjnT03ariWyrBL9cS4iOr3KM/8hSutLgScikKW0KKFtqOIAq5w==",
+      "version": "0.6.26",
+      "resolved": "https://github.com/GovWifi/govwifi-shared-frontend/releases/download/v0.6.26/govwifi-shared-frontend-0.6.26.tgz",
+      "integrity": "sha512-2WpN51fhm65L0EKnlwr3LH8V1U8G3jmJeC9NEV7mR4KrWLTNdcnYdCm/t+tRY+yWlIFQEgKynOLhipztIOCCFQ==",
       "license": "MIT",
       "dependencies": {
-        "js-cookie": "^3.0.7"
+        "js-cookie": "^3.0.8"
       },
       "engines": {
         "node": ">=18.17.0",
@@ -37,13 +37,10 @@
       }
     },
     "node_modules/js-cookie": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
-      "integrity": "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      }
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.8.tgz",
+      "integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/GovWifi/govwifi-tech-docs#readme",
   "dependencies": {
     "govuk-frontend": "^6.0.0",
-    "govwifi-shared-frontend": "https://github.com/GovWifi/govwifi-shared-frontend/releases/download/v0.6.21/govwifi-shared-frontend-0.6.21.tgz"
+    "govwifi-shared-frontend": "https://github.com/GovWifi/govwifi-shared-frontend/releases/download/v0.6.26/govwifi-shared-frontend-0.6.26.tgz"
   },
   "scripts": {
     "install": "./copy-assets.rb"


### PR DESCRIPTION
### What
Bump govwifi-shared-frontend to 0.6.26

### Why
Bump govwifi-shared-frontend to 0.6.26


### Link to Jira card (if applicable): 
[GW-xxxx](https://technologyprogramme.atlassian.net/browse/GW-xxxx)
